### PR TITLE
Solves issue #27. Lowercased variables and fixed shellcheck warnings (Bash)

### DIFF
--- a/day01-chronal-calibration/main.bash
+++ b/day01-chronal-calibration/main.bash
@@ -2,7 +2,7 @@
 
 # read input from stdin
 input=()
-while read line; do
+while read -r line; do
     input+=($line)
 done
 
@@ -11,8 +11,8 @@ done
 result=0
 
 # add every freq in input to RESULT
-for freq in ${input[@]}; do
-    result=$(($result + $freq))
+for freq in "${input[@]}"; do
+    result=$((result + freq))
 done
 
 echo $result
@@ -29,7 +29,7 @@ input_index=0               # Our current index in the input array
 while true; do
 
     # if already seen, break. we're done
-    if [[ -v seen[$current] ]]; then
+    if [[ ${seen[$current]+_} ]]; then
         break
     fi
 

--- a/day01-chronal-calibration/main.bash
+++ b/day01-chronal-calibration/main.bash
@@ -1,52 +1,52 @@
 #!/bin/bash
 
 # read input from stdin
-INPUT=()
-while read LINE; do
-    INPUT+=($LINE)
+input=()
+while read line; do
+    input+=($line)
 done
 
 # PART 1
 
-RESULT=0
+result=0
 
 # add every freq in input to RESULT
-for VAR in ${INPUT[@]}; do
-    RESULT=$(($RESULT + $VAR))
+for freq in ${input[@]}; do
+    result=$(($result + $freq))
 done
 
-echo $RESULT
+echo $result
 
 # PART 2
 # Takes a few seconds :)
 # The map functionality requires Bash 4.3 according to https://stackoverflow.com/a/30757358
 
-declare -A SEEN             # Map of seen frequencies (used as set)
-CURRENT=0                   # current freq
-INPUT_LENGTH=${#INPUT[@]}   # the length of the input array (stored for readability)
-INPUT_INDEX=0               # Our current index in the input array
+declare -A seen             # Map of seen frequencies (used as set)
+current=0                   # current freq
+input_length=${#input[@]}   # the length of the input array (stored for readability)
+input_index=0               # Our current index in the input array
 
 while true; do
 
     # if already seen, break. we're done
-    if [[ -v SEEN[$CURRENT] ]]; then
+    if [[ -v seen[$current] ]]; then
         break
     fi
 
     # add to seen
     # (value not used)
-    SEEN[$CURRENT]=1
+    seen[$current]=1
 
     # calc next freq
-    CHANGE="${INPUT[$INPUT_INDEX]}"
-    CURRENT=$((CURRENT + CHANGE))
+    change="${input[$input_index]}"
+    current=$((current + change))
 
     # make sure the loop wraps
-    ((INPUT_INDEX++))
-    if [[ $INPUT_INDEX -ge $INPUT_LENGTH ]]; then
-        INPUT_INDEX=0
+    ((input_index++))
+    if [[ $input_index -ge $input_length ]]; then
+        input_index=0
     fi
 done
 
-echo $CURRENT
+echo $current
 

--- a/day02-inventory-management-system/main.bash
+++ b/day02-inventory-management-system/main.bash
@@ -2,7 +2,7 @@
 
 # read input from stdin
 input=()
-while read line; do
+while read -r line; do
     input+=($line)
 done
 
@@ -13,7 +13,7 @@ first_num=0
 second_num=0
 
 
-for id in ${input[@]}; do
+for id in "${input[@]}"; do
 
     unset count
     declare -A count
@@ -24,7 +24,7 @@ for id in ${input[@]}; do
         # update count map
         # - if not seen yet -> make new entry with value 1
         # - if seen before -> increment
-        if [ ${count[$letter]+_} ]; then
+        if [ "${count[$letter]+_}" ]; then
             count[$letter]=$(( ${count[$letter]} + 1 ))
         else
             count[$letter]=1
@@ -59,7 +59,7 @@ for id in ${input[@]}; do
 
 done
 
-echo "$(($first_num * $second_num ))"
+echo "$(( first_num * second_num ))"
 
 
 # PART 2
@@ -94,7 +94,7 @@ for (( i=0; i<${#ids[@]}; i++ )); do
     id1=${ids[$i]}
 
     # compare ID1 to every id coming after it (as ID2)
-    for (( j=$(( $i + 1 )); j<${#ids[@]}; j++ )); do
+    for (( j=$(( i + 1 )); j<${#ids[@]}; j++ )); do
 
         id2=${ids[$j]}
 
@@ -106,7 +106,7 @@ for (( i=0; i<${#ids[@]}; i++ )); do
             letter1="${id1:$k:1}"
             letter2="${id2:$k:1}"
 
-            if [[ $letter1 != $letter2 ]]; then
+            if [[ $letter1 != "$letter2" ]]; then
                 ((num_diff++))
                 latest_diff_pos=$k
             fi
@@ -117,7 +117,7 @@ for (( i=0; i<${#ids[@]}; i++ )); do
 
             # build answer by removing different character
             left_answer_substr=${id1:0:$latest_diff_pos}
-            right_answer_substr=${id1:$(( $latest_diff_pos + 1)):${#id1}}
+            right_answer_substr=${id1:$(( latest_diff_pos + 1)):${#id1}}
 
             echo "$left_answer_substr$right_answer_substr"
             solution_found=true

--- a/day02-inventory-management-system/main.bash
+++ b/day02-inventory-management-system/main.bash
@@ -1,66 +1,65 @@
 #!/bin/bash
 
 # read input from stdin
-INPUT=()
-while read LINE; do
-    INPUT+=($LINE)
+input=()
+while read line; do
+    input+=($line)
 done
 
 # PART 1
 
 # answer is eq to these two multiplied
-FIRST_NUM=0
-SECOND_NUM=0
+first_num=0
+second_num=0
 
 
+for id in ${input[@]}; do
 
-for ID in ${INPUT[@]}; do
+    unset count
+    declare -A count
+    for (( i=0; i<${#id}; i++ )); do
 
-    unset COUNT
-    declare -A COUNT
-    for (( i=0; i<${#ID}; i++ )); do
-
-        LETTER="${ID:$i:1}"
+        letter="${id:$i:1}"
 
         # update count map
         # - if not seen yet -> make new entry with value 1
         # - if seen before -> increment
-        if [ ${COUNT[$LETTER]+_} ]; then
-            COUNT[$LETTER]=$(( ${COUNT[$LETTER]} + 1 ))
+        if [ ${count[$letter]+_} ]; then
+            count[$letter]=$(( ${count[$letter]} + 1 ))
         else
-            COUNT[$LETTER]=1
+            count[$letter]=1
         fi
 
     done
 
     # loop through checking for twins and triplets
-    HAS_TWIN=false
-    HAS_TRIPLET=false
-    for K in "${!COUNT[@]}"; do 
+    has_twin=false
+    has_triplet=false
+    for k in "${!count[@]}"; do 
 
-        if [[ ${COUNT[$K]} = 2 ]]; then
-            HAS_TWIN=true
+        if [[ ${count[$k]} = 2 ]]; then
+            has_twin=true
         fi
 
-        if [[ ${COUNT[$K]} = 3 ]]; then
-            HAS_TRIPLET=true
+        if [[ ${count[$k]} = 3 ]]; then
+            has_triplet=true
         fi
 
     done
 
     # update first and second num
 
-    if [[ $HAS_TWIN = true ]]; then
-        ((FIRST_NUM++))
+    if [[ $has_twin = true ]]; then
+        ((first_num++))
     fi 
 
-    if [[ $HAS_TRIPLET = true ]]; then
-        ((SECOND_NUM++))
+    if [[ $has_triplet = true ]]; then
+        ((second_num++))
     fi 
 
 done
 
-echo "$(($FIRST_NUM * $SECOND_NUM ))"
+echo "$(($first_num * $second_num ))"
 
 
 # PART 2
@@ -80,48 +79,48 @@ echo "$(($FIRST_NUM * $SECOND_NUM ))"
 #       output answer
 
 
-SOLUTION_FOUND=false
-IDS=(${INPUT[@]})
+solution_found=false
+ids=(${input[@]})
 
-for (( i=0; i<${#IDS[@]}; i++ )); do
+for (( i=0; i<${#ids[@]}; i++ )); do
 
     # If found solution, stop looping
     # (this should be in the for-loop condition above, but 
     #  didn't find a way to do this :p)
-    if [[ $SOLUTION_FOUND = true ]]; then
+    if [[ $solution_found = true ]]; then
         break
     fi
 
-    ID1=${IDS[$i]}
+    id1=${ids[$i]}
 
     # compare ID1 to every id coming after it (as ID2)
-    for (( j=$(( $i + 1 )); j<${#IDS[@]}; j++ )); do
+    for (( j=$(( $i + 1 )); j<${#ids[@]}; j++ )); do
 
-        ID2=${IDS[$j]}
+        id2=${ids[$j]}
 
         # count num different letters
-        NUM_DIFF=0
-        LATEST_DIFF_POS=0
-        for (( k=0; k<${#ID1}; k++ )); do
+        num_diff=0
+        latest_diff_pos=0
+        for (( k=0; k<${#id1}; k++ )); do
 
-            LETTER1="${ID1:$k:1}"
-            LETTER2="${ID2:$k:1}"
+            letter1="${id1:$k:1}"
+            letter2="${id2:$k:1}"
 
-            if [[ $LETTER1 != $LETTER2 ]]; then
-                ((NUM_DIFF++))
-                LATEST_DIFF_POS=$k
+            if [[ $letter1 != $letter2 ]]; then
+                ((num_diff++))
+                latest_diff_pos=$k
             fi
         done
 
         # if found diff of one
-        if [[ $NUM_DIFF == 1 ]]; then
+        if [[ $num_diff == 1 ]]; then
 
             # build answer by removing different character
-            LEFT_ANSWER_SUBSTR=${ID1:0:$LATEST_DIFF_POS}
-            RIGHT_ANSWER_SUBSTR=${ID1:$(( $LATEST_DIFF_POS + 1)):${#ID1}}
+            left_answer_substr=${id1:0:$latest_diff_pos}
+            right_answer_substr=${id1:$(( $latest_diff_pos + 1)):${#id1}}
 
-            echo "$LEFT_ANSWER_SUBSTR$RIGHT_ANSWER_SUBSTR"
-            SOLUTION_FOUND=true
+            echo "$left_answer_substr$right_answer_substr"
+            solution_found=true
             break
         fi
 

--- a/day03-no-matter-how-you-slice-it/main.bash
+++ b/day03-no-matter-how-you-slice-it/main.bash
@@ -17,15 +17,15 @@ while read -r claim; do
 
     # don't question the awk..... it works...
     # source https://kuther.net/howtos/howto-print-text-between-tags-or-characters-awk-or-sed
-    claim_id=$(echo $claim | awk -F'[#| ]' '{print $2}')
-    claim_x=$(echo $claim | awk -F'[@ |,]' '{print $4}')
-    claim_y=$(echo $claim | awk -F'[,|:]' '{print $2}')
-    claim_w=$(echo $claim | awk -F'[ |x]' '{print $4}')
-    claim_h=$(echo $claim | awk -F'[x|$]' '{print $2}')
+    claim_id=$(echo "$claim" | awk -F'[#| ]' '{print $2}')
+    claim_x=$(echo "$claim" | awk -F'[@ |,]' '{print $4}')
+    claim_y=$(echo "$claim" | awk -F'[,|:]' '{print $2}')
+    claim_w=$(echo "$claim" | awk -F'[ |x]' '{print $4}')
+    claim_h=$(echo "$claim" | awk -F'[x|$]' '{print $2}')
 
     # precalculate so don't have to spawn subshells in loop
-    claim_xw=$(( $claim_x + $claim_w ))
-    claim_yh=$(( $claim_y + $claim_h ))
+    claim_xw=$(( claim_x + claim_w ))
+    claim_yh=$(( claim_y + claim_h ))
 
     # store parsed info for part 2
     claim_map[$claim_counter,id]=$claim_id
@@ -35,8 +35,8 @@ while read -r claim; do
     claim_map[$claim_counter,y2]=$claim_yh
 
     # "paint" claim on fabric, while counting overlaps
-    for (( i=$claim_x; i<$claim_xw; i++ )); do
-        for (( j=$claim_y; j<$claim_yh; j++ )); do
+    for (( i=claim_x; i<claim_xw; i++ )); do
+        for (( j=claim_y; j<claim_yh; j++ )); do
             case ${fabric_map[$i,$j]} in
                 "")
                     fabric_map[$i,$j]=1

--- a/day03-no-matter-how-you-slice-it/main.bash
+++ b/day03-no-matter-how-you-slice-it/main.bash
@@ -7,47 +7,43 @@
 
 # PART 1
 
-declare -A FABRIC_MAP
-declare -A CLAIM_MAP
-CLAIM_COUNTER=-1
-OVERLAP_COUNT=0
-while read -r CLAIM; do
+declare -A fabric_map
+declare -A claim_map
+claim_counter=-1
+overlap_count=0
+while read -r claim; do
 
-
-    ((CLAIM_COUNTER++))
-
+    ((claim_counter++))
 
     # don't question the awk..... it works...
     # source https://kuther.net/howtos/howto-print-text-between-tags-or-characters-awk-or-sed
-    CLAIM_ID=$(echo $CLAIM | awk -F'[#| ]' '{print $2}')
-    CLAIM_X=$(echo $CLAIM | awk -F'[@ |,]' '{print $4}')
-    CLAIM_Y=$(echo $CLAIM | awk -F'[,|:]' '{print $2}')
-    CLAIM_W=$(echo $CLAIM | awk -F'[ |x]' '{print $4}')
-    CLAIM_H=$(echo $CLAIM | awk -F'[x|$]' '{print $2}')
+    claim_id=$(echo $claim | awk -F'[#| ]' '{print $2}')
+    claim_x=$(echo $claim | awk -F'[@ |,]' '{print $4}')
+    claim_y=$(echo $claim | awk -F'[,|:]' '{print $2}')
+    claim_w=$(echo $claim | awk -F'[ |x]' '{print $4}')
+    claim_h=$(echo $claim | awk -F'[x|$]' '{print $2}')
 
     # precalculate so don't have to spawn subshells in loop
-    CLAIM_XW=$(( $CLAIM_X + $CLAIM_W ))
-    CLAIM_YH=$(( $CLAIM_Y + $CLAIM_H ))
+    claim_xw=$(( $claim_x + $claim_w ))
+    claim_yh=$(( $claim_y + $claim_h ))
 
     # store parsed info for part 2
-    CLAIM_MAP[$CLAIM_COUNTER,id]=$CLAIM_ID
-    CLAIM_MAP[$CLAIM_COUNTER,x1]=$CLAIM_X
-    CLAIM_MAP[$CLAIM_COUNTER,y1]=$CLAIM_Y
-    CLAIM_MAP[$CLAIM_COUNTER,x2]=$CLAIM_XW
-    CLAIM_MAP[$CLAIM_COUNTER,y2]=$CLAIM_YH
+    claim_map[$claim_counter,id]=$claim_id
+    claim_map[$claim_counter,x1]=$claim_x
+    claim_map[$claim_counter,y1]=$claim_y
+    claim_map[$claim_counter,x2]=$claim_xw
+    claim_map[$claim_counter,y2]=$claim_yh
 
     # "paint" claim on fabric, while counting overlaps
-    for (( i=$CLAIM_X; i<$CLAIM_XW; i++ )); do
-        for (( j=$CLAIM_Y; j<$CLAIM_YH; j++ )); do
-            case ${FABRIC_MAP[$i,$j]} in
+    for (( i=$claim_x; i<$claim_xw; i++ )); do
+        for (( j=$claim_y; j<$claim_yh; j++ )); do
+            case ${fabric_map[$i,$j]} in
                 "")
-                    FABRIC_MAP[$i,$j]=1
+                    fabric_map[$i,$j]=1
                     ;;
                 1)
-                    FABRIC_MAP[$i,$j]=X
-                    ((OVERLAP_COUNT++))
-                    ;;
-                X)
+                    fabric_map[$i,$j]=X
+                    ((overlap_count++))
                     ;;
             esac
         done
@@ -55,34 +51,34 @@ while read -r CLAIM; do
 
 done
 
-echo $OVERLAP_COUNT
+echo $overlap_count
 
 # PART 2
 
 # find claim that have no X in the FABRIC_MAP
-for (( i=0; i<$(( CLAIM_COUNTER + 1 )); i++ )); do
+for (( i=0; i<$(( claim_counter + 1 )); i++ )); do
 
-    DOES_OVERLAP=false
+    does_overlap=false
 
-    for (( j=${CLAIM_MAP[$i,x1]}; j<${CLAIM_MAP[$i,x2]}; j++ )); do
+    for (( j=${claim_map[$i,x1]}; j<${claim_map[$i,x2]}; j++ )); do
 
         # if found soltuion -> break
         # (should be part of above for conditional, but still haven't 
         #  figured out how in Bash)
-        if [[ $DOES_OVERLAP = true ]]; then
+        if [[ $does_overlap = true ]]; then
             break
         fi
 
-        for (( k=${CLAIM_MAP[$i,y1]}; k<${CLAIM_MAP[$i,y2]}; k++ )); do
-            if [[ ${FABRIC_MAP[$j,$k]} -eq X ]]; then
-                DOES_OVERLAP=true
+        for (( k=${claim_map[$i,y1]}; k<${claim_map[$i,y2]}; k++ )); do
+            if [[ ${fabric_map[$j,$k]} -eq X ]]; then
+                does_overlap=true
                 break
             fi
         done
     done
 
-    if [[ $DOES_OVERLAP = false ]]; then
-        echo ${CLAIM_MAP[$i,id]}
+    if [[ $does_overlap = false ]]; then
+        echo ${claim_map[$i,id]}
         break
     fi
 


### PR DESCRIPTION
Solves issue #27.

Ouput from test and shellshock, since these aren't automatically run:

```
tholok:~/code/forked$ npm run bash

> adventofcode2018@ bash /home/tholok/code/forked
> ava --verbose --match='*.bash'


  ✖ No tests found in day04-respose-record/test.js
  ✖ No tests found in day05-alchemical-reduction/test.js
  ✔ day01-chronal-calibration › test › main.bash (10.6s)
  ✔ day02-inventory-management-system › test › main.bash (19.8s)
  ✔ day03-no-matter-how-you-slice-it › test › main.bash (3m 58.3s)

  3 tests passed

tholok:~/code/forked$ shellcheck day01-chronal-calibration/main.bash
tholok:~/code/forked$ shellcheck day02-inventory-management-system/main.bash
tholok:~/code/forked$ shellcheck day03-no-matter-how-you-slice-it/main.bash
```

# Notes about shellshock fixes

* Run with no options.
* Many "globbing" warnings. Reference: http://tldp.org/LDP/abs/html/globbingref.html. Fixed.
* Many `$ unnecessary inside $/${}` warnings. Fixed.