### PR TITLE
day01-cpp - part 2, 73x faster

### DIFF
--- a/day01-chronal-calibration/main.cpp
+++ b/day01-chronal-calibration/main.cpp
@@ -29,11 +29,13 @@ int main(int argc, char** argv)
 
 
     // Calculates puzzle 2;
-    std::unordered_set<int> duplicates;
+    std::unordered_set<int> duplicates{};
+    constexpr int n262144 = 2*2*2*2*2*2*2*2*2*2*2*2*2*2*2*2*2*2;
+    duplicates.reserve(n262144);
     int current = 0;
     bool found = false;
 
-    // auto begin = std::chrono::steady_clock::now();
+    auto begin = std::chrono::steady_clock::now();
     while (!found)
     {
         for (const auto& var : input)
@@ -45,9 +47,9 @@ int main(int argc, char** argv)
             }
         }
     }
-    // auto end = std::chrono::steady_clock::now();
-       // std::cout << "T2 = " << std::chrono::duration_cast<std::chrono::microseconds>(end - begin).count() << "us\n";
+    auto end = std::chrono::steady_clock::now();
+    std::cout << "T2 = " << std::chrono::duration_cast<std::chrono::microseconds>(end - begin).count() << "us\n";
 
-    std::cout << current << '\n';
+    std::cout << current << " " << duplicates.size() <<'\n';
     return 0;
 }

--- a/day01-chronal-calibration/main.cpp
+++ b/day01-chronal-calibration/main.cpp
@@ -18,7 +18,6 @@ int main(int argc, char** argv)
         input.push_back(atoi(line.c_str()));
     }
 
-
     // Calculates puzzle 1
     int total = 0;
     for (const auto& var : input)
@@ -40,7 +39,6 @@ int main(int argc, char** argv)
     int32_t current = 0;
     bool found = false;
 
-    auto begin = std::chrono::steady_clock::now();
     while (!found)
     {
         for (const auto& var : input)
@@ -56,9 +54,6 @@ int main(int argc, char** argv)
             bit_field[field_index] |= (0b1 << bit_index);
         }
     }
-    auto end = std::chrono::steady_clock::now();
-    std::cout << "T2 = " << std::chrono::duration_cast<std::chrono::microseconds>(end - begin).count() << "us\n";
-
     std::cout << current <<'\n';
     return 0;
 }

--- a/day01-chronal-calibration/main.cpp
+++ b/day01-chronal-calibration/main.cpp
@@ -1,11 +1,8 @@
 #include <iostream>
 #include <string>
-#include <unordered_set>
 #include <vector>
 
-#include <chrono>
-
-int main(int argc, char** argv)
+int main()
 {
     std::vector<std::string> lines{};
     for (std::string line; std::getline(std::cin, line);) {
@@ -18,7 +15,9 @@ int main(int argc, char** argv)
         input.push_back(atoi(line.c_str()));
     }
 
-    // Calculates puzzle 1
+    //
+    // Part1
+    //
     int total = 0;
     for (const auto& var : input)
     {
@@ -27,11 +26,9 @@ int main(int argc, char** argv)
     std::cout << total << '\n';
 
 
-    // Calculates puzzle 2;
-    //constexpr int n262144 = 2*2*2*2*2*2*2*2*2*2*2*2*2*2*2*2*2*2;
-    //std::unordered_set<int> duplicates{};
-    //duplicates.reserve(n262144);
-    
+    //
+    // Part 2
+    //
     constexpr int32_t n32768  = 2*2*2*2*2*2*2*2*2*2*2*2*2*2*2;
     constexpr int32_t n524288 = 2*2*2*2*2*2*2*2*2*2*2*2*2*2*2*2*2*2*2;
 

--- a/day01-chronal-calibration/main.cpp
+++ b/day01-chronal-calibration/main.cpp
@@ -1,7 +1,9 @@
 #include <iostream>
 #include <string>
-#include <set>
+#include <unordered_set>
 #include <vector>
+
+#include <chrono>
 
 int main(int argc, char** argv)
 {
@@ -16,34 +18,36 @@ int main(int argc, char** argv)
         input.push_back(atoi(line.c_str()));
     }
 
+
     // Calculates puzzle 1
     int total = 0;
-    for (auto var : input)
+    for (const auto& var : input)
     {
         total += var;
     }
-
     std::cout << total << '\n';
 
 
     // Calculates puzzle 2;
-    std::set<int> duplicates;
+    std::unordered_set<int> duplicates;
     int current = 0;
     bool found = false;
+
+    // auto begin = std::chrono::steady_clock::now();
     while (!found)
     {
-        for (auto var : input)
+        for (const auto& var : input)
         {
             current += var;
-
-            if (duplicates.find(current) != duplicates.end()) {
-                std::cout << current << '\n';
+            if (!duplicates.insert(current).second) {
                 found = true;
                 break;                
             }
-            
-            duplicates.insert(current);
         }
     }
+    // auto end = std::chrono::steady_clock::now();
+       // std::cout << "T2 = " << std::chrono::duration_cast<std::chrono::microseconds>(end - begin).count() << "us\n";
+
+    std::cout << current << '\n';
     return 0;
 }

--- a/day01-chronal-calibration/main.cpp
+++ b/day01-chronal-calibration/main.cpp
@@ -5,25 +5,27 @@
 int main()
 {
     std::vector<std::string> lines{};
-    for (std::string line; std::getline(std::cin, line);) {
-        lines.push_back(line);
+    for (std::string line; std::getline(std::cin, line);) 
+    {
+        lines.emplace_back(line);
     }
 
     std::string line;
     std::vector<int> input;
-    for (const auto& line: lines) {
-        input.push_back(atoi(line.c_str()));
+    for (const std::string& line: lines) 
+    {
+        input.emplace_back(atoi(line.c_str()));
     }
 
     //
     // Part1
     //
     int total = 0;
-    for (const auto& var : input)
+    for (const auto& var : input) 
     {
         total += var;
     }
-    std::cout << total << '\n';
+    printf("%d\n", total);
 
 
     //
@@ -41,7 +43,7 @@ int main()
         for (const auto& var : input)
         {
             current += var;
-            const int32_t field_index = (current + n524288) / 32;
+            const int32_t field_index = (current + n524288) >> 5;
             const int32_t bit_index = (current + n524288) % 32;
 
             if (bit_field[field_index] & (0b1 << bit_index)) {
@@ -51,6 +53,6 @@ int main()
             bit_field[field_index] |= (0b1 << bit_index);
         }
     }
-    std::cout << current <<'\n';
+    printf("%d\n", current);
     return 0;
 }

--- a/day01-chronal-calibration/main.cpp
+++ b/day01-chronal-calibration/main.cpp
@@ -29,10 +29,15 @@ int main(int argc, char** argv)
 
 
     // Calculates puzzle 2;
-    std::unordered_set<int> duplicates{};
-    constexpr int n262144 = 2*2*2*2*2*2*2*2*2*2*2*2*2*2*2*2*2*2;
-    duplicates.reserve(n262144);
-    int current = 0;
+    //constexpr int n262144 = 2*2*2*2*2*2*2*2*2*2*2*2*2*2*2*2*2*2;
+    //std::unordered_set<int> duplicates{};
+    //duplicates.reserve(n262144);
+    
+    constexpr int32_t n32768  = 2*2*2*2*2*2*2*2*2*2*2*2*2*2*2;
+    constexpr int32_t n524288 = 2*2*2*2*2*2*2*2*2*2*2*2*2*2*2*2*2*2*2;
+
+    int32_t bit_field[n32768] = {};
+    int32_t current = 0;
     bool found = false;
 
     auto begin = std::chrono::steady_clock::now();
@@ -41,15 +46,19 @@ int main(int argc, char** argv)
         for (const auto& var : input)
         {
             current += var;
-            if (!duplicates.insert(current).second) {
+            const int32_t field_index = (current + n524288) / 32;
+            const int32_t bit_index = (current + n524288) % 32;
+
+            if (bit_field[field_index] & (0b1 << bit_index)) {
                 found = true;
-                break;                
+                break;
             }
+            bit_field[field_index] |= (0b1 << bit_index);
         }
     }
     auto end = std::chrono::steady_clock::now();
     std::cout << "T2 = " << std::chrono::duration_cast<std::chrono::microseconds>(end - begin).count() << "us\n";
 
-    std::cout << current << " " << duplicates.size() <<'\n';
+    std::cout << current <<'\n';
     return 0;
 }


### PR DESCRIPTION
This was an experiment to see how much performance for day01part2 could improve from the naive implementation. I intend to only do this optimization for day01, as it is generally better if the code is easier to read, than being really fast. At least in this project.

**Notes**
- Testing on MBP2015
- Starting at 22ms for part 2 of day01
- 22ms -> 15ms - using `unordered_map` instead of `map`
- 15ms -> 11ms - using unordered_map::reserve, to allocate memory needed up-front.
- CPP solution  on-par with rust performance
- 11ms -> 0.35ms !!! - using bit-field to store visited numbers.
- Dangerous, only supports integers in range [-250k, 250k] now, but it is enough to solve for the given input data. Range could easily increase, if needed.
- 0.35ms -> 0.30ms by `>> 5` instead of  `/ 32`