### PR TITLE
Day06 bash logic fix (issue #39)

### DIFF
--- a/day06-chronal-coordinates/main.bash
+++ b/day06-chronal-coordinates/main.bash
@@ -5,22 +5,21 @@ input=$(</dev/stdin)
 parsed_input=($(echo "$input" | sed 's/,//;s/\n//'))
 
 # Notes from my solve:
+# TODO: clean up before commit (if you're seeing this I did a booboo)
 : << 'END_COMMENT'
-a coordinate is finite if there exists another coordinate with:
-* lower x
-* higher x
-* lower y
-* higher y
+a coordinate is finite if it does not have a coordinate on the edge of the search area
 
 process:
-* find finite coordinates.
-* find top left, top right.
-* fill out grid from top left to top right, 
-  while keeping track of coordinates with a total manhattan distance less than $region_max (part 2)
+* find top left, top right -> defines area to search
+* for each x,y in search area find closests coordinate
+
 * count which of the coordinates have the highest number of locations associated with them (part 1)
 END_COMMENT
 
-length=${#parsed_input[@]}
+input_length=${#parsed_input[@]}
+
+# determine search area
+input_length=${#parsed_input[@]}
 
 # initialize top left and bottom right to be the first coordinate
 # (just to have an actual coordinate to start with, will probably be overwritten)
@@ -29,75 +28,44 @@ top_left_y=${parsed_input[1]}
 bottom_right_x=${parsed_input[0]}
 bottom_right_y=${parsed_input[1]}
 
-# find finite coordinates, and add them to the $finite_coordinate_ids array
-# (see heredoc at top for logic)
-# (this section could probably be sped up if some IQ is applied :p)
-finite_coordinate_ids=()
-for (( i=0; i<length; i+=2 )); do
+
+for (( i=0; i<input_length; i+=2 )); do
     j=$(( i + 1 ))
 
     my_x=${parsed_input[$i]}
     my_y=${parsed_input[$j]}
 
-    lower_x=false
-    lower_y=false
-    higher_x=false
-    higher_y=false
-
-    for (( k=0; k<length; k+=2 )); do
-        l=$(( k + 1 ))
-
-        check_x=${parsed_input[$k]}
-        check_y=${parsed_input[$l]}
-
-        if [[ $check_x -lt $my_x ]]; then lower_x=true; fi
-        if [[ $check_x -gt $my_x ]]; then higher_x=true; fi
-        if [[ $check_y -lt $my_y ]]; then lower_y=true; fi
-        if [[ $check_y -gt $my_y ]]; then higher_y=true; fi
-
-    done
-
-    if [[ $lower_x = true ]] &&
-       [[ $lower_y = true ]] &&
-       [[ $higher_x = true ]] &&
-       [[ $higher_y = true ]]; then
-
-        finite_coordinate_ids+=($i)
-
-    else
-
-        if [[ $my_x -lt $top_left_x ]]; then top_left_x=$my_x; fi
-        if [[ $my_y -lt $top_left_y ]]; then top_left_y=$my_y; fi
-        if [[ $my_x -gt $bottom_right_x ]]; then bottom_right_x=$my_x; fi
-        if [[ $my_y -gt $bottom_right_y ]]; then bottom_right_y=$my_y; fi
-
-    fi
+    if [[ $my_x -lt $top_left_x ]]; then top_left_x=$my_x; fi
+    if [[ $my_y -lt $top_left_y ]]; then top_left_y=$my_y; fi
+    if [[ $my_x -gt $bottom_right_x ]]; then bottom_right_x=$my_x; fi
+    if [[ $my_y -gt $bottom_right_y ]]; then bottom_right_y=$my_y; fi
 
 done
 
+echo "DEBUG: $top_left_x $top_left_y $bottom_right_x $bottom_right_y"
 
-# map is used as a fake two-dimentional array. value map[i,j] ends up holding either the id of the coordinate 
-# that is closest, or a "." if multiple coordinates are closest
-declare -A map
 
-# the absolute max manhattan distance is from the top left to the bottom right.
-# used as initial value of search for min
-max_dist=$(( bottom_right_x -top_left_x + bottom_right_y - top_left_y ))
+# TODO explain
+declare -A map_closest_coordinate_id
 
-# used for part 2
 region_max=10000
 inside_region_count=0
 
-# loop from top left to bottom right and fill map with values.
-for (( i=top_left_x; i<=bottom_right_x; i++ )); do
-    for (( j=top_left_y; j<=bottom_right_y; j++ )); do
+# the absolute max manhattan distance is from the top left to the bottom right.
+# used as initial value of search for min
+max_dist=$(( bottom_right_x - top_left_x + bottom_right_y - top_left_y ))
 
-        # determine dot
+
+for (( i=top_left_x; i<=bottom_right_x; ++i)); do
+    echo $i
+    for (( j=top_left_y; j<=bottom_right_y; ++j )); do
+
+
         dot=-1
         min_dist=$max_dist
-        
         total_manhattan=0
-        for (( k=0; k<length; k+=2 )); do
+        
+        for (( k=0; k<input_length; k+=2 )); do
 
             l=$(( k + 1 ))
 
@@ -109,12 +77,9 @@ for (( i=top_left_x; i<=bottom_right_x; i++ )); do
     
             manhattan_x_component=$(( check_x - i ))
             manhattan_y_component=$(( check_y - j ))
-            if [[ $manhattan_x_component -lt 0 ]]; then manhattan_x_component=$(( 0 - manhattan_x_component )); fi
-            if [[ $manhattan_y_component -lt 0 ]]; then manhattan_y_component=$(( 0 - manhattan_y_component )); fi 
-            manhattan=$(( manhattan_x_component + manhattan_y_component ))
 
-            # (for part 2)
-            ((total_manhattan+=manhattan))
+            # (absolute value using parameter expansion)
+            manhattan=$(( ${manhattan_x_component#-} + ${manhattan_y_component#-} ))
 
             # if found new min dist -> update dot with id of coordinate and update min_dist
             # if found same min_dist -> update dot to be "."
@@ -125,9 +90,11 @@ for (( i=top_left_x; i<=bottom_right_x; i++ )); do
                 dot="."
             fi
 
+            ((total_manhattan+=manhattan))
+
         done
 
-        map[$i,$j]=$dot
+        map_closest_coordinate_id[$i,$j]=$dot
 
         if [[ $total_manhattan -lt $region_max ]]; then
             ((inside_region_count++))
@@ -136,31 +103,52 @@ for (( i=top_left_x; i<=bottom_right_x; i++ )); do
     done
 done
 
-# store answer for part 2
-# (answer is number of locations that have a total manhattan distance to 
-#  all coordinates less than $region_max)
-part_2_answer=$inside_region_count
 
-# find finite with most locations on map
-max_val=0
-for id in "${finite_coordinate_ids[@]}"; do
+# determine inifinites
+# map used for lookup and uniqueness
+declare -A map_infinites
+for (( i=top_left_x; i<=bottom_right_x; i++ )); do
+    map_infinites[${map_closest_coordinate_id[$i,$top_left_y]}]=1
+    map_infinites[${map_closest_coordinate_id[$i,$bottom_right_y]}]=1
+done
+for (( i=top_left_y; i<=bottom_right_y; i++ )); do
+    map_infinites[${map_closest_coordinate_id[$top_left_y,$i]}]=1
+    map_infinites[${map_closest_coordinate_id[$bottom_right_x,$i]}]=1
+done
 
-    count=0
-    for (( i=top_left_x; i<=bottom_right_x; i++ )); do
-        for (( j=top_left_y; j<=bottom_right_y; j++ )); do
-            if [[ "$id" == "${map[$i,$j]}" ]]; then
-                ((count++))
-            fi
-        done
-    done
+echo "infinites: ${!map_infinites[@]}"
 
-    if [[ $count -gt $max_val ]]; then
-        max_val=$count
+# finites is (all coordinates) - (infinites)
+declare -A map_finites=()
+for (( i = 0; i < input_length; i += 2 )); do
+    if [[ -z ${map_infinites[$i]+_} ]]; then
+        map_finites[$i]=0
     fi
 done
 
-# part 1 answer is the size of the largest region
-part_1_answer=$max_val
 
-echo $part_1_answer
-echo $part_2_answer
+# calculate area of finite coordinates
+for (( i=top_left_x; i<=bottom_right_x; i++ )); do
+    for (( j=top_left_y; j<=bottom_right_y; j++ )); do
+        closest_coordinate="${map_closest_coordinate_id[$i,$j]}"
+        if [[ ${map_finites[$closest_coordinate]+_} ]]; then
+            map_finites[$closest_coordinate]=$(( map_finites[$closest_coordinate] + 1 ))
+        fi
+    done
+done
+
+echo "finites: "
+for var in "${!map_finites[@]}"; do
+    echo "$var ${map_finites[$var]}"
+done
+
+# find finite with max area
+max_area=-1
+for area in "${map_finites[@]}"; do
+    if [[ $area -gt $max_area ]]; then
+        max_area=$area
+    fi
+done
+
+echo $max_area
+echo $inside_region_count

--- a/day06-chronal-coordinates/main.bash
+++ b/day06-chronal-coordinates/main.bash
@@ -43,7 +43,6 @@ max_dist=$(( bottom_right_x - top_left_x + bottom_right_y - top_left_y ))
 # fill out map_closest_coordinate_id and determine inside_region_count by traversing search area 
 # while calculating manhattan distances to coordinates and determining closests coordinate
 for (( i=top_left_x; i<=bottom_right_x; ++i)); do
-    echo $i
     for (( j=top_left_y; j<=bottom_right_y; ++j )); do
 
         dot=-1
@@ -111,14 +110,14 @@ for (( i = 0; i < parsed_input_length; i += 2 )); do
 done
 
 # ("." could appear in finites. remove just to be sure)
-unset map_finites[.]
+unset 'map_finites[.]'
 
 # calculate area of finite coordinates
 for (( i=top_left_x; i<=bottom_right_x; i++ )); do
     for (( j=top_left_y; j<=bottom_right_y; j++ )); do
         closest_coordinate="${map_closest_coordinate_id[$i,$j]}"
         if [[ ${map_finites[$closest_coordinate]+_} ]]; then
-            map_finites[$closest_coordinate]=$(( map_finites[$closest_coordinate] + 1 ))
+            map_finites[$closest_coordinate]=$(( map_finites[\$closest_coordinate] + 1 ))
         fi
     done
 done


### PR DESCRIPTION
Fixed logic as discussed in #39.

Local test:
```
$ npm run generate && npm run bash day06-chronal-coordinates/

> adventofcode2018@ generate /home/tholok/code/adventofcode2018
> node generate.js

Generated day02-inventory-management-system/test.js
Generated day01-chronal-calibration/test.js
Generated day04-respose-record/test.js
Generated day05-alchemical-reduction/test.js
Generated day06-chronal-coordinates/test.js
Generated day07-the-sum-of-its-parts/test.js
Generated day09-marble-mania/test.js
Generated day10-the-stars-align/test.js
Generated day14-chocolates-chart/test.js
Generated day13-mine-cart-madness/test.js
Generated day15-beverage-bandits/test.js
Generated day11-chronal-charge/test.js
Generated day08-memory-maneuver/test.js
Generated day12-subterranean-sustainability/test.js
Generated day03-no-matter-how-you-slice-it/test.js

> adventofcode2018@ bash /home/tholok/code/adventofcode2018
> ava --verbose --match='*.bash' "day06-chronal-coordinates/"


  ✔ main.bash (2m 40.9s)
    ℹ 3909 === 3909 1 of 2
    ℹ 36238 === 36238 2 of 2

  1 test passed
```